### PR TITLE
abstract out docker cmd, use sudo

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@
 ^README\.Rmd$
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^misc$

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 .Ruserdata
+misc

--- a/R/check_docker.R
+++ b/R/check_docker.R
@@ -9,8 +9,8 @@
 check_docker <- function() {
 
   cmd <- suppressWarnings({
-      system2(
-      "docker",
+      docker(
+      "",
       stdout = FALSE,
       stderr = FALSE
       )

--- a/R/docker.R
+++ b/R/docker.R
@@ -1,0 +1,11 @@
+docker <- function(cmd, ...) {
+  win <- .Platform$OS.type == "windows"
+  if(!win) {
+    systemcmd <- "sudo"
+    realcmd <- paste("docker", cmd)
+  } else {
+    systemcmd <- "docker"
+    realcmd <- cmd
+  }
+  system2(systemcmd, realcmd, ...)
+}

--- a/R/docker_conn.R
+++ b/R/docker_conn.R
@@ -49,7 +49,7 @@ docker_connection <- function(name){
 #' @export
 list_containers<-function(){
   dockercontainers<-tempfile()
-  writeLines(system("docker ps -a",intern = TRUE),dockercontainers)
+  writeLines(docker("ps -a",stdout = TRUE),dockercontainers)
   header<-readLines(dockercontainers,n = 1)
 
   locs<-as.numeric(gregexpr(pattern = "\\s\\s\\w",header)[[1]])
@@ -121,7 +121,7 @@ print.docker_connection<-function(x,...){
 #' @export
 list_images<-function(){
   dockerimages<-tempfile()
-  writeLines(system("docker image ls ",intern = TRUE),dockerimages)
+  writeLines(docker("image ls ",stdout = TRUE),dockerimages)
   header<-readLines(dockerimages,n = 1)
 
   locs<-as.numeric(gregexpr(pattern = "\\s\\s\\w",header)[[1]])

--- a/R/docker_run.R
+++ b/R/docker_run.R
@@ -25,7 +25,7 @@ docker_run <- function(image,name,ports,mountpoints,docker_run_args){
     stop("Must use a valid name without spaces")
   }}
 
-  run_cmd<-"docker run --rm -d"
+  run_cmd<-"run --rm -d"
 
   if(!missing(ports)){
     if(!grepl("\\d+[:]\\d+",ports)){
@@ -51,7 +51,7 @@ docker_run <- function(image,name,ports,mountpoints,docker_run_args){
 
   run_cmd <- paste(run_cmd,image)
 
-  start_results<-system(run_cmd,intern = TRUE)
+  start_results<-docker(run_cmd,stdout = TRUE)
 
   if(!is.null(attr(start_results,"status"))){
   if(attr(start_results,"status")!=0){
@@ -85,8 +85,8 @@ docker_kill.character<-function(x){
 #' @export
 docker_kill.docker_connection<-function(x){
   id <- attr(x,".docker_id")
-  kill_cmd <- paste("docker kill",id)
-  result<-system(kill_cmd,intern = TRUE)
+  kill_cmd <- paste("kill",id)
+  result<-docker(kill_cmd,stdout = TRUE)
   if(is.null(attr(result,"status"))){
     message("Killed Docker Container: ",attr(x,".name"))
   }
@@ -110,8 +110,8 @@ docker_stop.character<-function(x){
 #' @export
 docker_stop.docker_connection<-function(x){
   id <- attr(x,".docker_id")
-  stop_cmd <- paste("docker stop",id)
-  result<-system(stop_cmd,intern = TRUE)
+  stop_cmd <- paste("stop",id)
+  result<-docker(stop_cmd,stdout = TRUE)
   if(is.null(attr(result,"status"))){
     message("Stopped Docker Container: ",attr(x,".name"))
   }
@@ -134,8 +134,8 @@ docker_pause.character<-function(x){
 #' @export
 docker_pause.docker_connection<-function(x){
   id <- attr(x,".docker_id")
-  rm_cmd <- paste("docker pause",id)
-  result<-system(rm_cmd,intern = TRUE)
+  rm_cmd <- paste("pause",id)
+  result<-docker(rm_cmd,stdout = TRUE)
   if(is.null(attr(result,"status"))){
     message("Paused Docker Container: ",attr(x,".name"))
   }
@@ -152,15 +152,15 @@ docker_unpause<-function(x){
 }
 #' @export
 docker_unpause.character<-function(x){
-  conn<-docker_connection(x)
+  conn <- docker_connection(x)
   docker_unpause.docker_connection(conn)
 }
 #' @export
 docker_unpause.docker_connection<-function(x){
-  id <- attr(x,".docker_id")
-  rm_cmd <- paste("docker unpause",id)
-  result<-system(rm_cmd,intern = TRUE)
-  if(is.null(attr(result,"status"))){
-    message("Unpaused Docker Container: ",attr(x,".name"))
+  id <- attr(x, ".docker_id")
+  rm_cmd <- paste("unpause", id)
+  result <- docker(rm_cmd, stdout = TRUE)
+  if(is.null(attr(result, "status"))){
+    message("Unpaused Docker Container: ", attr(x, ".name"))
   }
 }

--- a/R/dockerfile_build.R
+++ b/R/dockerfile_build.R
@@ -59,7 +59,7 @@ build_from_dockerfile <- function(path, image, builddir = ".", verbose = TRUE) {
     stop("`docker` needs to be added to your execution path.")
   }
 
-  cmd <- paste("docker build -f",path, "-t", image, builddir)
+  cmd <- paste("build -f",path, "-t", image, builddir)
   # print(cmd)
-  system(cmd,intern = TRUE,show.output.on.console = verbose)
+  docker(cmd,stdout = TRUE)
 }


### PR DESCRIPTION
This PR does a couple of things:

- Collects all the various system calls to run docker into one function `docker`
- `docker` then checks the OS type, and uses `sudo` to run docker if required.

Not (yet) implemented: using processx instead of `system`, sudo passwords